### PR TITLE
issue#3 人口推移を取得するhooksを作成

### DIFF
--- a/src/hooks/usePopulationComposition.test.tsx
+++ b/src/hooks/usePopulationComposition.test.tsx
@@ -1,0 +1,363 @@
+import 'isomorphic-fetch';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { usePopulationComposition } from './usePopulationComposition';
+
+let replacedEnv: jest.ReplaceProperty<typeof process.env> | undefined = undefined;
+let mockFetch: jest.Spied<typeof global.fetch> | undefined = undefined;
+
+const populationComposition = {
+  message: null,
+  result: {
+    boundaryYear: 2020,
+    data: [
+      {
+        label: '総人口',
+        data: [
+          {
+            year: 1980,
+            value: 12817,
+          },
+          {
+            year: 1985,
+            value: 12707,
+          },
+          {
+            year: 1990,
+            value: 12571,
+          },
+          {
+            year: 1995,
+            value: 12602,
+          },
+          {
+            year: 2000,
+            value: 12199,
+          },
+          {
+            year: 2005,
+            value: 11518,
+          },
+          {
+            year: 2010,
+            value: 10888,
+          },
+          {
+            year: 2015,
+            value: 10133,
+          },
+          {
+            year: 2020,
+            value: 9302,
+          },
+          {
+            year: 2025,
+            value: 8431,
+          },
+          {
+            year: 2030,
+            value: 7610,
+          },
+          {
+            year: 2035,
+            value: 6816,
+          },
+          {
+            year: 2040,
+            value: 6048,
+          },
+          {
+            year: 2045,
+            value: 5324,
+          },
+        ],
+      },
+      {
+        label: '年少人口',
+        data: [
+          {
+            year: 1980,
+            value: 2906,
+            rate: 22.67,
+          },
+          {
+            year: 1985,
+            value: 2769,
+            rate: 21.79,
+          },
+          {
+            year: 1990,
+            value: 2346,
+            rate: 18.66,
+          },
+          {
+            year: 1995,
+            value: 2019,
+            rate: 16.02,
+          },
+          {
+            year: 2000,
+            value: 1728,
+            rate: 14.17,
+          },
+          {
+            year: 2005,
+            value: 1442,
+            rate: 12.52,
+          },
+          {
+            year: 2010,
+            value: 1321,
+            rate: 12.13,
+          },
+          {
+            year: 2015,
+            value: 1144,
+            rate: 11.29,
+          },
+          {
+            year: 2020,
+            value: 936,
+            rate: 10.06,
+          },
+          {
+            year: 2025,
+            value: 822,
+            rate: 9.75,
+          },
+          {
+            year: 2030,
+            value: 705,
+            rate: 9.26,
+          },
+          {
+            year: 2035,
+            value: 593,
+            rate: 8.7,
+          },
+          {
+            year: 2040,
+            value: 513,
+            rate: 8.48,
+          },
+          {
+            year: 2045,
+            value: 443,
+            rate: 8.32,
+          },
+        ],
+      },
+      {
+        label: '生産年齢人口',
+        data: [
+          {
+            year: 1980,
+            value: 8360,
+            rate: 65.23,
+          },
+          {
+            year: 1985,
+            value: 8236,
+            rate: 64.81,
+          },
+          {
+            year: 1990,
+            value: 8144,
+            rate: 64.78,
+          },
+          {
+            year: 1995,
+            value: 8048,
+            rate: 63.86,
+          },
+          {
+            year: 2000,
+            value: 7595,
+            rate: 62.26,
+          },
+          {
+            year: 2005,
+            value: 7032,
+            rate: 61.05,
+          },
+          {
+            year: 2010,
+            value: 6387,
+            rate: 58.66,
+          },
+          {
+            year: 2015,
+            value: 5538,
+            rate: 54.65,
+          },
+          {
+            year: 2020,
+            value: 4756,
+            rate: 51.13,
+          },
+          {
+            year: 2025,
+            value: 4187,
+            rate: 49.66,
+          },
+          {
+            year: 2030,
+            value: 3693,
+            rate: 48.53,
+          },
+          {
+            year: 2035,
+            value: 3251,
+            rate: 47.7,
+          },
+          {
+            year: 2040,
+            value: 2681,
+            rate: 44.33,
+          },
+          {
+            year: 2045,
+            value: 2261,
+            rate: 42.47,
+          },
+        ],
+      },
+      {
+        label: '老年人口',
+        data: [
+          {
+            year: 1980,
+            value: 1550,
+            rate: 12.09,
+          },
+          {
+            year: 1985,
+            value: 1702,
+            rate: 13.39,
+          },
+          {
+            year: 1990,
+            value: 2081,
+            rate: 16.55,
+          },
+          {
+            year: 1995,
+            value: 2535,
+            rate: 20.12,
+          },
+          {
+            year: 2000,
+            value: 2876,
+            rate: 23.58,
+          },
+          {
+            year: 2005,
+            value: 3044,
+            rate: 26.43,
+          },
+          {
+            year: 2010,
+            value: 3179,
+            rate: 29.2,
+          },
+          {
+            year: 2015,
+            value: 3442,
+            rate: 33.97,
+          },
+          {
+            year: 2020,
+            value: 3578,
+            rate: 38.46,
+          },
+          {
+            year: 2025,
+            value: 3422,
+            rate: 40.59,
+          },
+          {
+            year: 2030,
+            value: 3212,
+            rate: 42.21,
+          },
+          {
+            year: 2035,
+            value: 2972,
+            rate: 43.6,
+          },
+          {
+            year: 2040,
+            value: 2854,
+            rate: 47.19,
+          },
+          {
+            year: 2045,
+            value: 2620,
+            rate: 49.21,
+          },
+        ],
+      },
+    ],
+  },
+};
+
+describe('usePopulationComposition', () => {
+  afterEach(() => {
+    replacedEnv?.restore();
+    mockFetch?.mockRestore();
+  });
+
+  test('APIエンドポイントがhttps://opendata.resas-portal.go.jp/api/v1/population/composition/perYearになっている', async () => {
+    replacedEnv = jest.replaceProperty(process, 'env', { RESAS_API_KEY: 'RESAS_API_KEY', ...process.env });
+    mockFetch = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response(JSON.stringify(populationComposition), { status: 200 }));
+
+    const queryClient = new QueryClient();
+    const wrapper = ({ children }: any) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+
+    const { result } = renderHook(() => usePopulationComposition([1]), { wrapper });
+    await waitFor(() => result.current.size > 0);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringMatching(
+        new RegExp(
+          'https://opendata.resas-portal.go.jp/api/v1/population/composition/perYear?'.replace(/([.?])/g, '\\$1') +
+            '(prefCode=1&cityCode=-|cityCode=-&prefCode=1)',
+        ),
+      ),
+      expect.anything(),
+    );
+  });
+
+  test('人口構成データを取得している', async () => {
+    replacedEnv = jest.replaceProperty(process, 'env', { RESAS_API_KEY: 'RESAS_API_KEY', ...process.env });
+    mockFetch = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response(JSON.stringify(populationComposition), { status: 200 }));
+
+    const queryClient = new QueryClient();
+    const wrapper = ({ children }: any) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+
+    const { result, rerender } = renderHook(() => usePopulationComposition([1]), { wrapper });
+    await waitFor(() => result.current.size > 0);
+    rerender();
+    const expected = new Map([
+      [
+        1,
+        {
+          boundaryYear: 2020,
+          data: new Map(
+            populationComposition.result.data.map((data) => [
+              data.label,
+              data.data.map(({ year, value }) => ({ year, value })),
+            ]),
+          ),
+        },
+      ],
+    ]);
+    expect(result.current).toEqual(expected);
+  });
+});

--- a/src/hooks/usePopulationComposition.tsx
+++ b/src/hooks/usePopulationComposition.tsx
@@ -66,7 +66,10 @@ export const usePopulationComposition = (prefCodes: number[]) => {
         const prefCode = result.data.prefCode;
         const boundaryYear = result.data.boundaryYear;
         const data = result.data.data.reduce((acc, data) => {
-          acc.set(data.label, data.data);
+          acc.set(
+            data.label,
+            data.data.map(({ year, value }) => ({ year, value })),
+          );
           return acc;
         }, new Map<string, { year: number; value: number }[]>());
 

--- a/src/hooks/usePopulationComposition.tsx
+++ b/src/hooks/usePopulationComposition.tsx
@@ -1,0 +1,81 @@
+import * as t from 'io-ts';
+import { useMemo } from 'react';
+
+import { useQueries } from '@tanstack/react-query';
+
+import { fetchResas } from '@/utils/fetchResas';
+
+const PopulationCompositionResponse = t.type({
+  result: t.type({
+    boundaryYear: t.number,
+    data: t.array(
+      t.type({
+        label: t.string,
+        data: t.array(
+          t.type({
+            year: t.number,
+            value: t.number,
+          }),
+        ),
+      }),
+    ),
+  }),
+});
+
+type PopulationCompositionResponse = t.TypeOf<typeof PopulationCompositionResponse>;
+
+export type PopulationComposition = {
+  boundaryYear: number;
+  data: Map<
+    string,
+    {
+      year: number;
+      value: number;
+    }[]
+  >;
+};
+
+export const usePopulationComposition = (prefCodes: number[]) => {
+  const queries = useMemo(() => {
+    return prefCodes.map((prefCode) => {
+      return {
+        queryKey: ['population/composition/perYear', prefCode],
+        queryFn: async () => {
+          const response = await fetchResas('/population/composition/perYear', {
+            prefCode: prefCode,
+            cityCode: '-',
+          });
+
+          const result = PopulationCompositionResponse.decode(response);
+          if (result._tag === 'Left') {
+            throw new Error('Invalid response');
+          }
+
+          return { prefCode, ...result.right.result };
+        },
+      };
+    });
+  }, [prefCodes]);
+
+  const data = useQueries({
+    queries,
+    combine: (results) => {
+      return results.reduce((acc, result) => {
+        if (!result.isSuccess) return acc;
+
+        const prefCode = result.data.prefCode;
+        const boundaryYear = result.data.boundaryYear;
+        const data = result.data.data.reduce((acc, data) => {
+          acc.set(data.label, data.data);
+          return acc;
+        }, new Map<string, { year: number; value: number }[]>());
+
+        acc.set(prefCode, { boundaryYear, data });
+
+        return acc;
+      }, new Map<number, PopulationComposition>());
+    },
+  });
+
+  return data;
+};

--- a/src/hooks/usePopulationComposition.tsx
+++ b/src/hooks/usePopulationComposition.tsx
@@ -60,23 +60,17 @@ export const usePopulationComposition = (prefCodes: number[]) => {
   const data = useQueries({
     queries,
     combine: (results) => {
-      return results.reduce((acc, result) => {
-        if (!result.isSuccess) return acc;
-
-        const prefCode = result.data.prefCode;
-        const boundaryYear = result.data.boundaryYear;
-        const data = result.data.data.reduce((acc, data) => {
-          acc.set(
-            data.label,
-            data.data.map(({ year, value }) => ({ year, value })),
-          );
-          return acc;
-        }, new Map<string, { year: number; value: number }[]>());
-
-        acc.set(prefCode, { boundaryYear, data });
-
-        return acc;
-      }, new Map<number, PopulationComposition>());
+      return new Map(
+        results
+          .filter((result) => result.isSuccess && !!result.data)
+          .map(({ data: { prefCode, data, boundaryYear } }) => [
+            prefCode,
+            {
+              boundaryYear,
+              data: new Map(data.map(({ label, data }) => [label, data.map(({ year, value }) => ({ year, value }))])),
+            },
+          ]),
+      );
     },
   });
 


### PR DESCRIPTION
close #3 
- 人口推移を取得するhooksを作成しました

## 変更点
- `https://opendata.resas-portal.go.jp/api/v1/population/composition/perYear?` から人口推移をフェッチする `usePopulationComposition` を作成しました。
- `usePopulationComposition` についてテストを作成し、テストを行いました。

## テスト方法
`usePopulationComposition.test.tsx` について `pnpm test` によりテストを行い、テストを通過することを確認しました。