### PR TITLE
issue#18 useQuery, useQuerysで2回目以降のリクエストを行わない

### DIFF
--- a/src/hooks/usePopulationComposition/index.tsx
+++ b/src/hooks/usePopulationComposition/index.tsx
@@ -39,6 +39,7 @@ export const usePopulationComposition = (prefCodes: number[]) => {
   const queries = useMemo(() => {
     return prefCodes.map((prefCode) => {
       return {
+        staleTime: Infinity,
         queryKey: ['population/composition/perYear', prefCode],
         queryFn: async () => {
           const response = await fetchResas('/population/composition/perYear', {

--- a/src/hooks/usePrefectures/index.tsx
+++ b/src/hooks/usePrefectures/index.tsx
@@ -20,6 +20,7 @@ export type Prefecture = {
 
 export const usePrefectures = () => {
   const { data } = useQuery({
+    staleTime: Infinity,
     queryKey: ['prefectures'],
     queryFn: async () => {
       const response = await fetchResas('/prefectures', {});


### PR DESCRIPTION
close #18 
- useQuery, useQuerysにおいてstaleTimeが設定されておらず、再描画の度にfetchが発生していたので、staleTimeをInfinityに変更しました。

## 変更内容
- useQuery, useQuerys についてstaleTimeをInfinityに変更しました。

## テスト方法
- `pnpm test` により、従来のテストを通過することを確認しました。