### PR TITLE
Feat/issue#31 人口データの分類を選択するためのセレクタを追加

### DIFF
--- a/src/components/atoms/SelectPopulationCategory/index.module.scss
+++ b/src/components/atoms/SelectPopulationCategory/index.module.scss
@@ -1,0 +1,31 @@
+@use 'themes' as *;
+
+.container {
+  position: relative;
+  color: $color-on-primary;
+  background-color: $color-primary;
+  border-radius: 0.25em;
+}
+
+.select {
+  padding: 0.25em 2em 0.25em 0.5em;
+  outline: none;
+
+  &-option {
+    color: $color-on-surface;
+    background-color: $color-surface;
+
+    &[data-checked='true'] {
+      color: $color-on-primary-container;
+      background-color: $color-primary-container;
+    }
+  }
+}
+
+.arrow {
+  position: absolute;
+  top: 50%;
+  right: 0.5em;
+  pointer-events: none;
+  transform: translateY(-50%);
+}

--- a/src/components/atoms/SelectPopulationCategory/index.tsx
+++ b/src/components/atoms/SelectPopulationCategory/index.tsx
@@ -1,0 +1,24 @@
+import { useCallback } from 'react';
+
+export type SelectPopulationCategoryProps = {
+  categoryLabel: string;
+  onChange: (categoryLabel: string) => void;
+};
+
+export const SelectPopulationCategory = ({ categoryLabel, onChange }: SelectPopulationCategoryProps) => {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      onChange(e.currentTarget.value);
+    },
+    [onChange],
+  );
+
+  return (
+    <select value={categoryLabel} onChange={handleChange}>
+      <option value='総人口'>総人口</option>
+      <option value='年少人口'>年少人口</option>
+      <option value='生産年齢人口'>生産年齢人口</option>
+      <option value='老年人口'>老年人口</option>
+    </select>
+  );
+};

--- a/src/components/atoms/SelectPopulationCategory/index.tsx
+++ b/src/components/atoms/SelectPopulationCategory/index.tsx
@@ -1,5 +1,7 @@
 import { useCallback } from 'react';
 
+import styles from './index.module.scss';
+
 export type SelectPopulationCategoryProps = {
   categoryLabel: string;
   onChange: (categoryLabel: string) => void;
@@ -14,11 +16,26 @@ export const SelectPopulationCategory = ({ categoryLabel, onChange }: SelectPopu
   );
 
   return (
-    <select value={categoryLabel} onChange={handleChange}>
-      <option value='総人口'>総人口</option>
-      <option value='年少人口'>年少人口</option>
-      <option value='生産年齢人口'>生産年齢人口</option>
-      <option value='老年人口'>老年人口</option>
-    </select>
+    <div className={styles['container']}>
+      <select value={categoryLabel} onChange={handleChange} className={styles['select']}>
+        <option value='総人口' data-checked={categoryLabel === '総人口'} className={styles['select-option']}>
+          総人口
+        </option>
+        <option value='年少人口' data-checked={categoryLabel === '年少人口'} className={styles['select-option']}>
+          年少人口
+        </option>
+        <option
+          value='生産年齢人口'
+          data-checked={categoryLabel === '生産年齢人口'}
+          className={styles['select-option']}
+        >
+          生産年齢人口
+        </option>
+        <option value='老年人口' data-checked={categoryLabel === '老年人口'} className={styles['select-option']}>
+          老年人口
+        </option>
+      </select>
+      <div className={styles['arrow']}>&#x25BC;</div>
+    </div>
   );
 };

--- a/src/components/molecules/PopulationChartContainer/index.module.scss
+++ b/src/components/molecules/PopulationChartContainer/index.module.scss
@@ -1,0 +1,12 @@
+.container {
+  display: grid;
+  grid-template-columns: 1fr;
+  row-gap: 1rem;
+  justify-items: end;
+}
+
+.item {
+  &--full {
+    width: 100%;
+  }
+}

--- a/src/components/molecules/PopulationChartContainer/index.tsx
+++ b/src/components/molecules/PopulationChartContainer/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { PopulationChart } from '@/components/atoms/PopulationChart';
+import { SelectPopulationCategory } from '@/components/atoms/SelectPopulationCategory';
 import { SelectPrefectures } from '@/components/atoms/SelectPrefectures';
 
 import { usePopulationChartContainer } from './usePopulationChartContainer';
@@ -8,12 +9,22 @@ import { usePopulationChartContainer } from './usePopulationChartContainer';
 export type PopulationChartContainerProps = {};
 
 export const PopulationChartContainer = ({}: PopulationChartContainerProps) => {
-  const { prefCodesSet, prefCodesList, handleChangeSelectedPref } = usePopulationChartContainer();
+  const {
+    prefCodesSet,
+    prefCodesList,
+    populationCategoryLabel,
+    handleChangeSelectedPref,
+    handleChangePopulationCategoryLabel,
+  } = usePopulationChartContainer();
 
   return (
     <>
       <SelectPrefectures prefCodesSet={prefCodesSet} onChangeSelect={handleChangeSelectedPref} />
-      <PopulationChart prefCodes={prefCodesList} categoryLabel='総人口' />
+      <SelectPopulationCategory
+        categoryLabel={populationCategoryLabel}
+        onChange={handleChangePopulationCategoryLabel}
+      />
+      <PopulationChart prefCodes={prefCodesList} categoryLabel={populationCategoryLabel} />
     </>
   );
 };

--- a/src/components/molecules/PopulationChartContainer/index.tsx
+++ b/src/components/molecules/PopulationChartContainer/index.tsx
@@ -4,6 +4,7 @@ import { PopulationChart } from '@/components/atoms/PopulationChart';
 import { SelectPopulationCategory } from '@/components/atoms/SelectPopulationCategory';
 import { SelectPrefectures } from '@/components/atoms/SelectPrefectures';
 
+import styles from './index.module.scss';
 import { usePopulationChartContainer } from './usePopulationChartContainer';
 
 export type PopulationChartContainerProps = {};
@@ -18,13 +19,17 @@ export const PopulationChartContainer = ({}: PopulationChartContainerProps) => {
   } = usePopulationChartContainer();
 
   return (
-    <>
-      <SelectPrefectures prefCodesSet={prefCodesSet} onChangeSelect={handleChangeSelectedPref} />
+    <section className={styles['container']}>
+      <div className={styles['item--full']}>
+        <SelectPrefectures prefCodesSet={prefCodesSet} onChangeSelect={handleChangeSelectedPref} />
+      </div>
       <SelectPopulationCategory
         categoryLabel={populationCategoryLabel}
         onChange={handleChangePopulationCategoryLabel}
       />
-      <PopulationChart prefCodes={prefCodesList} categoryLabel={populationCategoryLabel} />
-    </>
+      <div className={styles['item--full']}>
+        <PopulationChart prefCodes={prefCodesList} categoryLabel={populationCategoryLabel} />
+      </div>
+    </section>
   );
 };

--- a/src/components/molecules/PopulationChartContainer/usePopulationChartContainer.tsx
+++ b/src/components/molecules/PopulationChartContainer/usePopulationChartContainer.tsx
@@ -4,9 +4,13 @@ export const usePopulationChartContainer = () => {
   const [prefCodesSet, setPrefCodeSet] = useState(new Set<number>());
   const prefCodesList = useMemo(() => Array.from(prefCodesSet).sort(), [prefCodesSet]);
 
+  const [populationCategoryLabel, setPopulationCategoryLabel] = useState('総人口');
+
   return {
     prefCodesSet,
     prefCodesList,
+    populationCategoryLabel,
     handleChangeSelectedPref: setPrefCodeSet,
+    handleChangePopulationCategoryLabel: setPopulationCategoryLabel,
   };
 };


### PR DESCRIPTION
closes #31 
- 人口データの分類を選択するためのセレクタを追加しました。

## 変更点
- 人口データの分類を選択するためのセレクタを追加しました。
- `PopulationChartContainer` コンポーネントについて、スタイルを追加しました。

## テスト方法
- `pnpm test` により、従来のテストを通過することを確認しました。
- 人口データの分類を選択し、それに応じたグラフに切り替わることを確認しました

|「総人口」選択時|「年少人口」選択時|「生産年齢人口」選択時|「老年人口」選択時|
|:-:|:-:|:-:|:-:|
|![localhost_3000_ (4)](https://github.com/user-attachments/assets/dc84f511-7f5c-47bf-84a4-26d1472473a4)|![localhost_3000_ (5)](https://github.com/user-attachments/assets/90447f14-db10-4abb-89c5-16ff25638ed7)|![localhost_3000_ (6)](https://github.com/user-attachments/assets/384d0da9-8245-4a3e-802c-5b12a79429b7)|![localhost_3000_ (7)](https://github.com/user-attachments/assets/d52f0bcf-10b3-4b77-a465-ae0136a43995)|
