### PR TITLE
issue#32 fetchResasを利用したテストにおけるfetchを、mswに統合する

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-unused-imports": "^3.2.0",
-    "isomorphic-fetch": "^3.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "msw": "^2.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,9 +67,6 @@ devDependencies:
   eslint-plugin-unused-imports:
     specifier: ^3.2.0
     version: 3.2.0(eslint@8.57.0)
-  isomorphic-fetch:
-    specifier: ^3.0.0
-    version: 3.0.0
   jest:
     specifier: ^29.7.0
     version: 29.7.0(@types/node@20.14.10)(ts-node@10.9.2)
@@ -3632,15 +3629,6 @@ packages:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
 
-  /isomorphic-fetch@3.0.0:
-    resolution: {integrity: sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==}
-    dependencies:
-      node-fetch: 2.7.0
-      whatwg-fetch: 3.6.20
-    transitivePeerDependencies:
-      - encoding
-    dev: true
-
   /istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -4549,18 +4537,6 @@ packages:
       - '@babel/core'
       - babel-plugin-macros
     dev: false
-
-  /node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-    dependencies:
-      whatwg-url: 5.0.0
-    dev: true
 
   /node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -5678,10 +5654,6 @@ packages:
       url-parse: 1.5.10
     dev: true
 
-  /tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-    dev: true
-
   /tr46@3.0.0:
     resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
     engines: {node: '>=12'}
@@ -5914,10 +5886,6 @@ packages:
       makeerror: 1.0.12
     dev: true
 
-  /webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-    dev: true
-
   /webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -5928,10 +5896,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       iconv-lite: 0.6.3
-    dev: true
-
-  /whatwg-fetch@3.6.20:
-    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
     dev: true
 
   /whatwg-mimetype@3.0.0:
@@ -5945,13 +5909,6 @@ packages:
     dependencies:
       tr46: 3.0.0
       webidl-conversions: 7.0.0
-    dev: true
-
-  /whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
     dev: true
 
   /which-boxed-primitive@1.0.2:

--- a/src/hooks/usePopulationComposition/index.test.tsx
+++ b/src/hooks/usePopulationComposition/index.test.tsx
@@ -1,316 +1,28 @@
-import 'isomorphic-fetch';
-
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
+
+import { server } from '@/mocks/server';
 
 import { usePopulationComposition } from './index';
 
 let mockFetch: jest.Spied<typeof global.fetch> | undefined = undefined;
 
-const populationComposition = {
-  message: null,
-  result: {
-    boundaryYear: 2020,
-    data: [
-      {
-        label: '総人口',
-        data: [
-          {
-            year: 1980,
-            value: 12817,
-          },
-          {
-            year: 1985,
-            value: 12707,
-          },
-          {
-            year: 1990,
-            value: 12571,
-          },
-          {
-            year: 1995,
-            value: 12602,
-          },
-          {
-            year: 2000,
-            value: 12199,
-          },
-          {
-            year: 2005,
-            value: 11518,
-          },
-          {
-            year: 2010,
-            value: 10888,
-          },
-          {
-            year: 2015,
-            value: 10133,
-          },
-          {
-            year: 2020,
-            value: 9302,
-          },
-          {
-            year: 2025,
-            value: 8431,
-          },
-          {
-            year: 2030,
-            value: 7610,
-          },
-          {
-            year: 2035,
-            value: 6816,
-          },
-          {
-            year: 2040,
-            value: 6048,
-          },
-          {
-            year: 2045,
-            value: 5324,
-          },
-        ],
-      },
-      {
-        label: '年少人口',
-        data: [
-          {
-            year: 1980,
-            value: 2906,
-            rate: 22.67,
-          },
-          {
-            year: 1985,
-            value: 2769,
-            rate: 21.79,
-          },
-          {
-            year: 1990,
-            value: 2346,
-            rate: 18.66,
-          },
-          {
-            year: 1995,
-            value: 2019,
-            rate: 16.02,
-          },
-          {
-            year: 2000,
-            value: 1728,
-            rate: 14.17,
-          },
-          {
-            year: 2005,
-            value: 1442,
-            rate: 12.52,
-          },
-          {
-            year: 2010,
-            value: 1321,
-            rate: 12.13,
-          },
-          {
-            year: 2015,
-            value: 1144,
-            rate: 11.29,
-          },
-          {
-            year: 2020,
-            value: 936,
-            rate: 10.06,
-          },
-          {
-            year: 2025,
-            value: 822,
-            rate: 9.75,
-          },
-          {
-            year: 2030,
-            value: 705,
-            rate: 9.26,
-          },
-          {
-            year: 2035,
-            value: 593,
-            rate: 8.7,
-          },
-          {
-            year: 2040,
-            value: 513,
-            rate: 8.48,
-          },
-          {
-            year: 2045,
-            value: 443,
-            rate: 8.32,
-          },
-        ],
-      },
-      {
-        label: '生産年齢人口',
-        data: [
-          {
-            year: 1980,
-            value: 8360,
-            rate: 65.23,
-          },
-          {
-            year: 1985,
-            value: 8236,
-            rate: 64.81,
-          },
-          {
-            year: 1990,
-            value: 8144,
-            rate: 64.78,
-          },
-          {
-            year: 1995,
-            value: 8048,
-            rate: 63.86,
-          },
-          {
-            year: 2000,
-            value: 7595,
-            rate: 62.26,
-          },
-          {
-            year: 2005,
-            value: 7032,
-            rate: 61.05,
-          },
-          {
-            year: 2010,
-            value: 6387,
-            rate: 58.66,
-          },
-          {
-            year: 2015,
-            value: 5538,
-            rate: 54.65,
-          },
-          {
-            year: 2020,
-            value: 4756,
-            rate: 51.13,
-          },
-          {
-            year: 2025,
-            value: 4187,
-            rate: 49.66,
-          },
-          {
-            year: 2030,
-            value: 3693,
-            rate: 48.53,
-          },
-          {
-            year: 2035,
-            value: 3251,
-            rate: 47.7,
-          },
-          {
-            year: 2040,
-            value: 2681,
-            rate: 44.33,
-          },
-          {
-            year: 2045,
-            value: 2261,
-            rate: 42.47,
-          },
-        ],
-      },
-      {
-        label: '老年人口',
-        data: [
-          {
-            year: 1980,
-            value: 1550,
-            rate: 12.09,
-          },
-          {
-            year: 1985,
-            value: 1702,
-            rate: 13.39,
-          },
-          {
-            year: 1990,
-            value: 2081,
-            rate: 16.55,
-          },
-          {
-            year: 1995,
-            value: 2535,
-            rate: 20.12,
-          },
-          {
-            year: 2000,
-            value: 2876,
-            rate: 23.58,
-          },
-          {
-            year: 2005,
-            value: 3044,
-            rate: 26.43,
-          },
-          {
-            year: 2010,
-            value: 3179,
-            rate: 29.2,
-          },
-          {
-            year: 2015,
-            value: 3442,
-            rate: 33.97,
-          },
-          {
-            year: 2020,
-            value: 3578,
-            rate: 38.46,
-          },
-          {
-            year: 2025,
-            value: 3422,
-            rate: 40.59,
-          },
-          {
-            year: 2030,
-            value: 3212,
-            rate: 42.21,
-          },
-          {
-            year: 2035,
-            value: 2972,
-            rate: 43.6,
-          },
-          {
-            year: 2040,
-            value: 2854,
-            rate: 47.19,
-          },
-          {
-            year: 2045,
-            value: 2620,
-            rate: 49.21,
-          },
-        ],
-      },
-    ],
-  },
-};
-
 describe('usePopulationComposition', () => {
+  beforeAll(() => {
+    server.listen();
+  });
+
   afterEach(() => {
+    server.resetHandlers();
     mockFetch?.mockRestore();
   });
 
+  afterAll(() => {
+    server.close();
+  });
+
   test('APIエンドポイントがhttps://opendata.resas-portal.go.jp/api/v1/population/composition/perYearになっている', async () => {
-    mockFetch = jest
-      .spyOn(global, 'fetch')
-      .mockResolvedValue(new Response(JSON.stringify(populationComposition), { status: 200 }));
+    mockFetch = jest.spyOn(global, 'fetch');
 
     const queryClient = new QueryClient();
     const wrapper = ({ children }: any) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
@@ -329,22 +41,20 @@ describe('usePopulationComposition', () => {
     );
   });
 
-  test('人口構成データを取得している', async () => {
-    mockFetch = jest
-      .spyOn(global, 'fetch')
-      .mockResolvedValue(new Response(JSON.stringify(populationComposition), { status: 200 }));
-
+  test('prefCode=1の人口構成データを取得している', async () => {
     const queryClient = new QueryClient();
     const wrapper = ({ children }: any) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 
     const { result, rerender } = renderHook(() => usePopulationComposition([1]), { wrapper });
     await waitFor(() => result.current.size > 0);
     rerender();
+
+    const { response: populationComposition } = await import('@/mocks/resas/api/v1/population/composition/perYear/_1');
     const expected = new Map([
       [
         1,
         {
-          boundaryYear: 2020,
+          boundaryYear: populationComposition.result.boundaryYear,
           data: new Map(
             populationComposition.result.data.map((data) => [
               data.label,

--- a/src/hooks/usePrefectures/index.test.tsx
+++ b/src/hooks/usePrefectures/index.test.tsx
@@ -1,235 +1,44 @@
-import 'isomorphic-fetch';
-
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
+
+import { response as prefecturesResponse } from '@/mocks/resas/api/v1/prefectures';
+import { server } from '@/mocks/server';
 
 import { usePrefectures } from './index';
 
 let mockFetch: jest.Spied<typeof global.fetch> | undefined = undefined;
 
-const prefectures = {
-  message: null,
-  result: [
-    {
-      prefCode: 1,
-      prefName: '北海道',
-    },
-    {
-      prefCode: 2,
-      prefName: '青森県',
-    },
-    {
-      prefCode: 3,
-      prefName: '岩手県',
-    },
-    {
-      prefCode: 4,
-      prefName: '宮城県',
-    },
-    {
-      prefCode: 5,
-      prefName: '秋田県',
-    },
-    {
-      prefCode: 6,
-      prefName: '山形県',
-    },
-    {
-      prefCode: 7,
-      prefName: '福島県',
-    },
-    {
-      prefCode: 8,
-      prefName: '茨城県',
-    },
-    {
-      prefCode: 9,
-      prefName: '栃木県',
-    },
-    {
-      prefCode: 10,
-      prefName: '群馬県',
-    },
-    {
-      prefCode: 11,
-      prefName: '埼玉県',
-    },
-    {
-      prefCode: 12,
-      prefName: '千葉県',
-    },
-    {
-      prefCode: 13,
-      prefName: '東京都',
-    },
-    {
-      prefCode: 14,
-      prefName: '神奈川県',
-    },
-    {
-      prefCode: 15,
-      prefName: '新潟県',
-    },
-    {
-      prefCode: 16,
-      prefName: '富山県',
-    },
-    {
-      prefCode: 17,
-      prefName: '石川県',
-    },
-    {
-      prefCode: 18,
-      prefName: '福井県',
-    },
-    {
-      prefCode: 19,
-      prefName: '山梨県',
-    },
-    {
-      prefCode: 20,
-      prefName: '長野県',
-    },
-    {
-      prefCode: 21,
-      prefName: '岐阜県',
-    },
-    {
-      prefCode: 22,
-      prefName: '静岡県',
-    },
-    {
-      prefCode: 23,
-      prefName: '愛知県',
-    },
-    {
-      prefCode: 24,
-      prefName: '三重県',
-    },
-    {
-      prefCode: 25,
-      prefName: '滋賀県',
-    },
-    {
-      prefCode: 26,
-      prefName: '京都府',
-    },
-    {
-      prefCode: 27,
-      prefName: '大阪府',
-    },
-    {
-      prefCode: 28,
-      prefName: '兵庫県',
-    },
-    {
-      prefCode: 29,
-      prefName: '奈良県',
-    },
-    {
-      prefCode: 30,
-      prefName: '和歌山県',
-    },
-    {
-      prefCode: 31,
-      prefName: '鳥取県',
-    },
-    {
-      prefCode: 32,
-      prefName: '島根県',
-    },
-    {
-      prefCode: 33,
-      prefName: '岡山県',
-    },
-    {
-      prefCode: 34,
-      prefName: '広島県',
-    },
-    {
-      prefCode: 35,
-      prefName: '山口県',
-    },
-    {
-      prefCode: 36,
-      prefName: '徳島県',
-    },
-    {
-      prefCode: 37,
-      prefName: '香川県',
-    },
-    {
-      prefCode: 38,
-      prefName: '愛媛県',
-    },
-    {
-      prefCode: 39,
-      prefName: '高知県',
-    },
-    {
-      prefCode: 40,
-      prefName: '福岡県',
-    },
-    {
-      prefCode: 41,
-      prefName: '佐賀県',
-    },
-    {
-      prefCode: 42,
-      prefName: '長崎県',
-    },
-    {
-      prefCode: 43,
-      prefName: '熊本県',
-    },
-    {
-      prefCode: 44,
-      prefName: '大分県',
-    },
-    {
-      prefCode: 45,
-      prefName: '宮崎県',
-    },
-    {
-      prefCode: 46,
-      prefName: '鹿児島県',
-    },
-    {
-      prefCode: 47,
-      prefName: '沖縄県',
-    },
-  ],
-};
-
 describe('usePrefectures', () => {
+  beforeAll(() => {
+    server.listen();
+  });
+
   afterEach(() => {
+    server.resetHandlers();
     mockFetch?.mockRestore();
   });
 
-  test('APIエンドポイントがhttps://opendata.resas-portal.go.jp/api/v1/prefecturesになっている', async () => {
-    mockFetch = jest
-      .spyOn(global, 'fetch')
-      .mockResolvedValue(new Response(JSON.stringify(prefectures), { status: 200 }));
+  afterAll(() => {
+    server.close();
+  });
 
+  test('APIエンドポイントがhttps://opendata.resas-portal.go.jp/api/v1/prefecturesになっている', async () => {
+    mockFetch = jest.spyOn(global, 'fetch');
     const { result } = renderHook(() => usePrefectures(), {
       wrapper: ({ children }) => {
         return <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>;
       },
     });
     await waitFor(() => expect(result.current).not.toEqual([]));
-    expect(fetch).toHaveBeenCalledWith('https://opendata.resas-portal.go.jp/api/v1/prefectures', expect.anything());
+    expect(mockFetch).toHaveBeenCalledWith('https://opendata.resas-portal.go.jp/api/v1/prefectures', expect.anything());
   });
 
   test('都道府県一覧を取得している', async () => {
-    mockFetch = jest
-      .spyOn(global, 'fetch')
-      .mockResolvedValue(new Response(JSON.stringify(prefectures), { status: 200 }));
-
     const { result } = renderHook(() => usePrefectures(), {
       wrapper: ({ children }) => {
         return <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>;
       },
     });
-    await waitFor(() => expect(result.current).toEqual(prefectures.result));
+    await waitFor(() => expect(result.current).toEqual(prefecturesResponse.result));
   });
 });


### PR DESCRIPTION
close #32
- APIを利用したテストをmswに変更しました。

## 変更点
- `usePopulationComposition` および `usePrefectures` について、 `fetch` の戻り値をモックしていたものを、 `@mocks/server` に置き換えました。
  - 正常系については、テスト内にレスポンスを一々書く必要が減り、ボイラープレートが削減できます。
- `isomorphic-fetch` を使用する必要が無くなったので、削除しました。

## テスト方法
- `pnpm test` により、テストの結果が従来と変わらないことを確認しました。