### PR TITLE
issue#35 UIコンポーネントにテストを追加する

### DIFF
--- a/src/components/atoms/SelectPopulationCategory/index.test.tsx
+++ b/src/components/atoms/SelectPopulationCategory/index.test.tsx
@@ -1,0 +1,128 @@
+import { act } from 'react';
+
+import { render } from '@testing-library/react';
+
+import { server } from '@/mocks/server';
+
+import { SelectPopulationCategory } from './index';
+
+describe('SelectPopulationCategory', () => {
+  beforeAll(() => {
+    server.listen();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  test('「総人口」「年少人口」「生産年齢人口」「老年人口」の選択肢が表示される', async () => {
+    const handleChange = jest.fn();
+
+    render(<SelectPopulationCategory categoryLabel={'総人口'} onChange={handleChange} />);
+
+    expect(document.querySelector('option[value="総人口"]')).not.toBeNull();
+    expect(document.querySelector('option[value="年少人口"]')).not.toBeNull();
+    expect(document.querySelector('option[value="生産年齢人口"]')).not.toBeNull();
+    expect(document.querySelector('option[value="老年人口"]')).not.toBeNull();
+  });
+
+  test('categoryLabel="総人口"のとき、「総人口」が選択されている', async () => {
+    const handleChange = jest.fn();
+
+    render(<SelectPopulationCategory categoryLabel={'総人口'} onChange={handleChange} />);
+
+    const select = document.querySelector('select') as HTMLSelectElement;
+
+    expect(select.value).toBe('総人口');
+  });
+
+  test('categoryLabel="年少人口"のとき、「年少人口」が選択されている', async () => {
+    const handleChange = jest.fn();
+
+    render(<SelectPopulationCategory categoryLabel={'年少人口'} onChange={handleChange} />);
+
+    const select = document.querySelector('select') as HTMLSelectElement;
+
+    expect(select.value).toBe('年少人口');
+  });
+
+  test('categoryLabel="生産年齢人口"のとき、「生産年齢人口」が選択されている', async () => {
+    const handleChange = jest.fn();
+
+    render(<SelectPopulationCategory categoryLabel={'生産年齢人口'} onChange={handleChange} />);
+
+    const select = document.querySelector('select') as HTMLSelectElement;
+
+    expect(select.value).toBe('生産年齢人口');
+  });
+
+  test('categoryLabel="老年人口"のとき、「老年人口」が選択されている', async () => {
+    const handleChange = jest.fn();
+
+    render(<SelectPopulationCategory categoryLabel={'老年人口'} onChange={handleChange} />);
+
+    const select = document.querySelector('select') as HTMLSelectElement;
+
+    expect(select.value).toBe('老年人口');
+  });
+
+  test('「総人口」を選択すると、onChangeが("総人口")で発火する', async () => {
+    const handleChange = jest.fn();
+
+    render(<SelectPopulationCategory categoryLabel={'総人口'} onChange={handleChange} />);
+
+    const select = document.querySelector('select') as HTMLSelectElement;
+    act(() => {
+      select.value = '総人口';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    expect(handleChange).toHaveBeenCalledWith('総人口');
+  });
+
+  test('「年少人口」を選択すると、onChangeが("年少人口")で発火する', async () => {
+    const handleChange = jest.fn();
+
+    render(<SelectPopulationCategory categoryLabel={'総人口'} onChange={handleChange} />);
+
+    const select = document.querySelector('select') as HTMLSelectElement;
+    act(() => {
+      select.value = '年少人口';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    expect(handleChange).toHaveBeenCalledWith('年少人口');
+  });
+
+  test('「生産年齢人口」を選択すると、onChangeが("生産年齢人口")で発火する', async () => {
+    const handleChange = jest.fn();
+
+    render(<SelectPopulationCategory categoryLabel={'総人口'} onChange={handleChange} />);
+
+    const select = document.querySelector('select') as HTMLSelectElement;
+    act(() => {
+      select.value = '生産年齢人口';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    expect(handleChange).toHaveBeenCalledWith('生産年齢人口');
+  });
+
+  test('「老年人口」を選択すると、onChangeが("老年人口")で発火する', async () => {
+    const handleChange = jest.fn();
+
+    render(<SelectPopulationCategory categoryLabel={'総人口'} onChange={handleChange} />);
+
+    const select = document.querySelector('select') as HTMLSelectElement;
+    act(() => {
+      select.value = '老年人口';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    expect(handleChange).toHaveBeenCalledWith('老年人口');
+  });
+});

--- a/src/components/atoms/SelectPrefectures/PrefectureCheckbox.test.tsx
+++ b/src/components/atoms/SelectPrefectures/PrefectureCheckbox.test.tsx
@@ -1,0 +1,112 @@
+import { act } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+
+import { server } from '@/mocks/server';
+
+import { PrefectureCheckbox } from './PrefectureCheckbox';
+
+describe('PrefectureCheckbox', () => {
+  beforeAll(() => {
+    server.listen();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  test('prefNameが表示される', async () => {
+    const queryClient = new QueryClient();
+    const wrapper = ({ children }: any) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+
+    const handleChange = jest.fn();
+
+    render(<PrefectureCheckbox prefCode={1} prefName={'北海道'} isChecked={false} onChange={handleChange} />, {
+      wrapper,
+    });
+    await expect(screen.findByText('北海道')).resolves.toBeDefined();
+  });
+
+  test('inputにprefCodeが設定されている', async () => {
+    const queryClient = new QueryClient();
+    const wrapper = ({ children }: any) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+
+    const handleChange = jest.fn();
+
+    render(<PrefectureCheckbox prefCode={1} prefName={'北海道'} isChecked={false} onChange={handleChange} />, {
+      wrapper,
+    });
+
+    const checkbox = await screen.findByLabelText('北海道');
+    expect(checkbox).toHaveProperty('value', '1');
+  });
+
+  test('isChecked=falseのとき、inputのcheckedがfalseになる', async () => {
+    const queryClient = new QueryClient();
+    const wrapper = ({ children }: any) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+
+    const handleChange = jest.fn();
+
+    render(<PrefectureCheckbox prefCode={1} prefName={'北海道'} isChecked={false} onChange={handleChange} />, {
+      wrapper,
+    });
+
+    const checkbox = await screen.findByLabelText('北海道');
+    expect(checkbox).toHaveProperty('checked', false);
+  });
+
+  test('isChecked=trueのとき、inputのcheckedがtrueになる', async () => {
+    const queryClient = new QueryClient();
+    const wrapper = ({ children }: any) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+
+    const handleChange = jest.fn();
+
+    render(<PrefectureCheckbox prefCode={1} prefName={'北海道'} isChecked={true} onChange={handleChange} />, {
+      wrapper,
+    });
+
+    const checkbox = await screen.findByLabelText('北海道');
+    expect(checkbox).toHaveProperty('checked', true);
+  });
+
+  test('prefCode=1、isChecked=falseのとき、チェックボックスをクリックするとonChangeが(1,true)で発火する', async () => {
+    const queryClient = new QueryClient();
+    const wrapper = ({ children }: any) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+
+    const handleChange = jest.fn();
+
+    render(<PrefectureCheckbox prefCode={1} prefName={'北海道'} isChecked={false} onChange={handleChange} />, {
+      wrapper,
+    });
+
+    const checkbox = await screen.findByLabelText('北海道');
+    act(() => {
+      checkbox.click();
+    });
+
+    expect(handleChange).toHaveBeenCalledWith(1, true);
+  });
+
+  test('prefCode=1、isChecked=trueのとき、チェックボックスをクリックするとonChangeが(1,false)で発火する', async () => {
+    const queryClient = new QueryClient();
+    const wrapper = ({ children }: any) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+
+    const handleChange = jest.fn();
+
+    render(<PrefectureCheckbox prefCode={1} prefName={'北海道'} isChecked={true} onChange={handleChange} />, {
+      wrapper,
+    });
+
+    const checkbox = await screen.findByLabelText('北海道');
+    act(() => {
+      checkbox.click();
+    });
+
+    expect(handleChange).toHaveBeenCalledWith(1, false);
+  });
+});

--- a/src/components/atoms/SelectPrefectures/index.test.tsx
+++ b/src/components/atoms/SelectPrefectures/index.test.tsx
@@ -1,0 +1,129 @@
+import { act } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+
+import { server } from '@/mocks/server';
+
+import { SelectPrefectures } from './index';
+
+describe('SelectPrefectures', () => {
+  beforeAll(() => {
+    server.listen();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  test('すべての都道府県が選択肢にある', async () => {
+    const queryClient = new QueryClient();
+    const wrapper = ({ children }: any) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+
+    const prefCodesSet = new Set<number>();
+    const handleChangePrefCodesSet = jest.fn();
+
+    render(<SelectPrefectures prefCodesSet={prefCodesSet} onChangeSelect={handleChangePrefCodesSet} />, { wrapper });
+    await Promise.all([
+      expect(screen.findByLabelText('北海道')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('青森県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('岩手県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('宮城県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('秋田県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('山形県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('福島県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('茨城県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('栃木県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('群馬県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('埼玉県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('千葉県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('東京都')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('神奈川県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('新潟県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('富山県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('石川県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('福井県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('山梨県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('長野県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('岐阜県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('静岡県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('愛知県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('三重県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('滋賀県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('京都府')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('大阪府')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('兵庫県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('奈良県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('和歌山県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('鳥取県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('島根県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('岡山県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('広島県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('山口県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('徳島県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('香川県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('愛媛県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('高知県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('福岡県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('佐賀県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('長崎県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('熊本県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('大分県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('宮崎県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('鹿児島県')).resolves.toBeDefined(),
+      expect(screen.findByLabelText('沖縄県')).resolves.toBeDefined(),
+    ]);
+  });
+
+  test('北海道をクリックすると、[1]としてonChangeSelectが発火する', async () => {
+    const queryClient = new QueryClient();
+    const wrapper = ({ children }: any) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+
+    const prefCodesSet = new Set<number>();
+    const handleChangePrefCodesSet = jest.fn();
+    render(<SelectPrefectures prefCodesSet={prefCodesSet} onChangeSelect={handleChangePrefCodesSet} />, { wrapper });
+
+    const checkbox = await screen.findByLabelText('北海道');
+    act(() => {
+      checkbox.click();
+    });
+
+    expect(handleChangePrefCodesSet).toHaveBeenCalledWith(new Set([1]));
+  });
+
+  test('prefCodesSetが[1]のとき、青森県をクリックすると、[1,2]としてonChangeSelectが発火する', async () => {
+    const queryClient = new QueryClient();
+    const wrapper = ({ children }: any) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+
+    const prefCodesSet = new Set<number>([1]);
+    const handleChangePrefCodesSet = jest.fn();
+    render(<SelectPrefectures prefCodesSet={prefCodesSet} onChangeSelect={handleChangePrefCodesSet} />, { wrapper });
+
+    const checkbox = await screen.findByLabelText('青森県');
+    act(() => {
+      checkbox.click();
+    });
+
+    expect(handleChangePrefCodesSet).toHaveBeenCalledWith(new Set([1, 2]));
+  });
+
+  test('prefCodesSetが[1,2]のとき、北海道をクリックすると、[2]としてonChangeSelectが発火する', async () => {
+    const queryClient = new QueryClient();
+    const wrapper = ({ children }: any) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+
+    const prefCodesSet = new Set<number>([1, 2]);
+    const handleChangePrefCodesSet = jest.fn();
+    render(<SelectPrefectures prefCodesSet={prefCodesSet} onChangeSelect={handleChangePrefCodesSet} />, { wrapper });
+
+    const checkbox = await screen.findByLabelText('北海道');
+    act(() => {
+      checkbox.click();
+    });
+
+    expect(handleChangePrefCodesSet).toHaveBeenCalledWith(new Set([2]));
+  });
+});


### PR DESCRIPTION
Closes #35 
- UIコンポーネントにテストを追加しました。

## 変更点
- SelectPrefecturesにテストを追加しました。
- PrefectureCheckboxにテストを追加しました。
- SelectPopulationCategoryにテストを追加しました。

## 備考
- `PopulationChart` については、 rechartsが動的にsvgを生成する都合、現在の方法ではテストが難しく、 `usePopulationChartData` のテストのみで十分と考えられることもあり、テストを作成していません。

## テスト方法
- `pnpm test` により、テストを通過することを確認しました。