### PR TITLE
issue#37 pageコンポーネントの.containerがスクロールバーの外に出ないようにする

### DIFF
--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -1,7 +1,7 @@
 @use 'themes' as *;
 
 .container {
-  width: 100vw;
+  width: 100%;
   min-height: 100vh;
   color: $color-on-surface;
   background-color: $color-surface-container;


### PR DESCRIPTION
Closes #37 

## 変更点
- pageコンポーネントの.containerのwidthを100vwから100%に変更しました。

## テスト方法
- ブラウザ上の表示（Google Chrome）で、縦スクロールバーが表示された時に、横スクロールバーが出ないことを確認しました。
- `pnpm test` により、従来のテストを通過することを確認しました。